### PR TITLE
Add prayer request privacy moderation

### DIFF
--- a/.agents/skills/context-app-features/SKILL.md
+++ b/.agents/skills/context-app-features/SKILL.md
@@ -76,7 +76,9 @@ O usuário compartilha sua necessidade espiritual com a comunidade.
 - Salvo na tabela `prayer_requests`.
 - O autor ganha pontos de XP (uma vez ao dia).
 - O usuário pode dar feedback depois para os intercessores (ex: "Deu certo", "Não foi dessa vez, mas confio").
-- **Anonimato (Feature Planejada/Regra de Produto):** Pedidos podem ser anônimos. Ao sortear um pedido anônimo, NÃO exibir dados do autor (nome, foto).
+- **Anonimato por Pedido:** Pedidos podem ser marcados como anônimos no envio. Ao sortear um pedido anônimo, NÃO exibir dados do autor (nome, foto) para a comunidade. O `user_id` continua preservado para auditoria interna.
+- **Moderação Local de Conteúdo:** O envio passa por uma Edge Function com regras locais para detectar PII, contatos, documentos, endereços, links, pedidos financeiros, ofensas, ódio, ameaças, conteúdo sexual explícito e automutilação explícita.
+- **Revisão:** Pedidos suspeitos podem ser enviados como `pending_review`; pedidos confirmados como violação usam `policy_violation`. Ambos ficam fora da fila de novos sorteios e têm interações bloqueadas. Históricos exibem aviso e ocultam o conteúdo quando o status é restrito.
 
 ---
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -239,6 +239,56 @@ export type Database = {
         }
         Relationships: []
       }
+      prayer_moderation_reviews: {
+        Row: {
+          id: string
+          prayer_request_id: string | null
+          user_id: string
+          original_title: string | null
+          original_content: string
+          normalized_content: string
+          detected_policies: Json
+          risk_score: number
+          decision: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          prayer_request_id?: string | null
+          user_id: string
+          original_title?: string | null
+          original_content: string
+          normalized_content: string
+          detected_policies?: Json
+          risk_score?: number
+          decision?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          prayer_request_id?: string | null
+          user_id?: string
+          original_title?: string | null
+          original_content?: string
+          normalized_content?: string
+          detected_policies?: Json
+          risk_score?: number
+          decision?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prayer_moderation_reviews_prayer_request_id_fkey"
+            columns: ["prayer_request_id"]
+            isOneToOne: false
+            referencedRelation: "prayer_requests"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       prayer_reports: {
         Row: {
           id: string

--- a/src/pages/Pray.tsx
+++ b/src/pages/Pray.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Sparkles, Heart, ArrowLeft, Users, Share2, Clock, Loader2, Flag, Eye, MessageCircle, Check } from "lucide-react";
+import { Sparkles, Heart, ArrowLeft, Users, Share2, Clock, Loader2, Flag, Eye, MessageCircle, Check, ShieldAlert } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useXp } from "@/hooks/use-xp";
@@ -34,6 +34,17 @@ const REACTIONS = [
   { type: "strength", emoji: "💪", label: "Força" },
   { type: "empathy", emoji: "🥺", label: "Empatia" },
 ];
+
+const isRestrictedPrayer = (status?: string | null) =>
+  status === "pending_review" || status === "policy_violation" || status === "banned";
+
+const getRestrictedPrayerMessage = (status?: string | null) => {
+  if (status === "pending_review") {
+    return "Este pedido está em revisão e ainda não está disponível para a comunidade.";
+  }
+
+  return "Este pedido não pode continuar público porque não está de acordo com as políticas do Améns.";
+};
 
 const fadeUp = {
   initial: { opacity: 0, y: 20 },
@@ -241,7 +252,7 @@ const Pray = () => {
           created_at: i.created_at, // when user interceded
           posted_at: p.created_at, // when cause was created
           prayer_title: p.title || null,
-          prayer_content: p.status === 'banned' ? "[Causa removida por infringir as diretrizes do Améns]" : (p.content || "Pedido removido"),
+          prayer_content: isRestrictedPrayer(p.status) ? getRestrictedPrayerMessage(p.status) : (p.content || "Pedido removido"),
           prayer_location: p.location || null,
           prayer_feedback: p.feedback || null,
           author_name: authorNameFinal,
@@ -250,6 +261,7 @@ const Pray = () => {
           is_anonymous: p.is_anonymous,
           user_reaction: reactionsMap[i.prayer_request_id] || null,
           status: p.status,
+          is_restricted: isRestrictedPrayer(p.status),
           intercessionsCount: i.intercessionsCount,
           allIntercessions: i.allIntercessions
         };
@@ -336,7 +348,7 @@ const Pray = () => {
 
       if (error) throw error;
       if (data) {
-        if (data.status === 'banned') {
+        if (isRestrictedPrayer(data.status)) {
           toast.error("Esta causa não está mais disponível.");
           fetchRandomPrayerRequest();
           return;
@@ -376,6 +388,11 @@ const Pray = () => {
 
   const handleAcceptSharedCause = async () => {
     if (!prayerRequest) return;
+    if (isRestrictedPrayer(prayerRequest.status)) {
+      toast.error("Esta causa não está disponível para novas interações.");
+      return;
+    }
+
     if (useOneDraw()) {
       setIsSharedCause(false);
       await recordIntercession(prayerRequest.id);
@@ -502,6 +519,12 @@ const Pray = () => {
   };
 
   const forceDrawFromHistory = async (historyId: string, prayerId: string) => {
+    const historyItem = intercessions.find(item => item.id === historyId);
+    if (isRestrictedPrayer(historyItem?.status)) {
+      toast.error("Esta causa não está disponível para novas interações.");
+      return;
+    }
+
     if (!useOneDraw()) {
       toast.error("Limite diário de sorteios atingido.");
       return;
@@ -650,6 +673,14 @@ REGRAS ADICIONAIS:
 
   const toggleReaction = async (reactionType: string, targetPrayerId: string, currentReaction: string | null, onHistoryItem?: boolean) => {
     if (!currentUser) return;
+
+    const targetStatus = onHistoryItem
+      ? intercessions.find(item => item.prayer_request_id === targetPrayerId)?.status
+      : prayerRequest?.status;
+    if (isRestrictedPrayer(targetStatus)) {
+      toast.error("Esta causa está com interações bloqueadas.");
+      return;
+    }
     
     const isRemoving = currentReaction === reactionType;
     const newReaction = isRemoving ? null : reactionType;
@@ -817,7 +848,13 @@ REGRAS ADICIONAIS:
                     {/* Integrated Reactions Section */}
                     <div className="bg-primary/5 rounded-2xl p-5 mb-6 border border-primary/10">
                       <h4 className="text-sm font-semibold text-center text-primary mb-3">Envie Energia e Solidariedade</h4>
-                      {prayerRequest.feedback ? (
+                      {isRestrictedPrayer(prayerRequest.status) ? (
+                         <div className="text-center p-3 bg-amber-50 rounded-xl border border-amber-200">
+                            <ShieldAlert className="w-5 h-5 mx-auto mb-2 text-amber-700" />
+                            <p className="text-xs font-medium text-amber-800">{getRestrictedPrayerMessage(prayerRequest.status)}</p>
+                            <p className="text-[10px] text-muted-foreground mt-1">Interações desativadas</p>
+                         </div>
+                      ) : prayerRequest.feedback ? (
                          <div className="text-center p-3 bg-white/50 rounded-xl">
                             <span className="text-2xl mb-1 block">{FEEDBACK_OPTIONS[prayerRequest.feedback]?.emoji}</span>
                             <p className="text-xs font-medium text-green-700">Esta causa já recebeu um testemunho de graça!</p>
@@ -859,7 +896,7 @@ REGRAS ADICIONAIS:
                         {isGenerating ? "Gerando..." : "Sugestão de Oração"}
                       </Button>
                       
-                      {!prayerRequest.feedback && !isSharedCause && (
+                      {!isRestrictedPrayer(prayerRequest.status) && !prayerRequest.feedback && !isSharedCause && (
                         <Button onClick={fetchRandomPrayerRequest} variant="outline" className="border-[#1D4ED8]/20 text-[#1D4ED8] hover:text-[#1D4ED8] hover:bg-[#1D4ED8]/5 shadow-sm">
                           Próxima Causa
                         </Button>
@@ -886,7 +923,7 @@ REGRAS ADICIONAIS:
                        </Button>
                     </div>
 
-                    {!prayerRequest.feedback && !prayerRequest.is_default && !isSharedCause && (
+                    {!isRestrictedPrayer(prayerRequest.status) && !prayerRequest.feedback && !prayerRequest.is_default && !isSharedCause && (
                       <div className="mt-4 flex flex-col gap-3 items-center text-center">
                         <button onClick={() => setReportDialogOpen(true)} className="text-[10px] text-muted-foreground hover:text-red-500 transition-colors uppercase font-medium flex items-center justify-center gap-1 mx-auto">
                           <Flag className="w-3 h-3" /> Reportar essa causa a um administrador
@@ -970,7 +1007,7 @@ REGRAS ADICIONAIS:
                             animate={{ opacity: 1, x: 0 }} 
                             transition={{ delay: i * 0.1 }}
                           >
-                            <Card className={`p-5 soft-shadow rounded-3xl ${item.prayer_feedback ? 'bg-green-50/80 border-green-200' : 'border-primary/5'}`}>
+                            <Card className={`p-5 soft-shadow rounded-3xl ${item.is_restricted ? 'bg-amber-50/80 border-amber-200' : item.prayer_feedback ? 'bg-green-50/80 border-green-200' : 'border-primary/5'}`}>
                               <div className="flex gap-4">
                                 <div className="flex-shrink-0 mt-1">
                                   {item.avatar_url ? (
@@ -990,7 +1027,14 @@ REGRAS ADICIONAIS:
                                   </div>
                                   
                                   {item.prayer_title && <h4 className="text-sm font-bold mb-1 line-clamp-1">{item.prayer_title}</h4>}
-                                  <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed mb-3">{item.prayer_content}</p>
+                                  {item.is_restricted ? (
+                                    <div className="text-xs text-amber-800 bg-white/70 border border-amber-200 rounded-xl p-3 mb-3">
+                                      <p className="font-bold mb-1">Conteúdo indisponível</p>
+                                      <p>{item.prayer_content}</p>
+                                    </div>
+                                  ) : (
+                                    <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed mb-3">{item.prayer_content}</p>
+                                  )}
                                   
                                   <div className="flex flex-col w-full gap-2 mt-3 text-[10px] text-muted-foreground">
                                     <div className="flex items-center flex-wrap gap-x-2 gap-y-1">
@@ -1032,7 +1076,12 @@ REGRAS ADICIONAIS:
 
                                   {/* History Reactions */}
                                   <div className="mt-4 pt-3 border-t border-primary/5 flex items-center justify-between">
-                                    {item.prayer_feedback ? (
+                                    {item.is_restricted ? (
+                                      <div className="flex items-center gap-2 bg-amber-50 text-amber-700 px-3 py-1.5 rounded-xl border border-amber-200">
+                                        <ShieldAlert className="w-3.5 h-3.5" />
+                                        <span className="text-[10px] font-bold uppercase">Interações bloqueadas</span>
+                                      </div>
+                                    ) : item.prayer_feedback ? (
                                       <div className="flex items-center gap-2 bg-green-50 text-green-700 px-3 py-1.5 rounded-xl border border-green-100">
                                         <span className="text-lg">{FEEDBACK_OPTIONS[item.prayer_feedback]?.emoji}</span>
                                         <span className="text-[10px] font-bold uppercase">Graça alcançada!</span>
@@ -1068,7 +1117,7 @@ REGRAS ADICIONAIS:
                                       </div>
                                     )}
 
-                                    {!item.prayer_feedback && (
+                                    {!item.is_restricted && !item.prayer_feedback && (
                                       <Button 
                                         variant="outline" 
                                         size="sm" 

--- a/src/pages/Submit.tsx
+++ b/src/pages/Submit.tsx
@@ -1,18 +1,34 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  ArrowLeft,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Eye,
+  Heart,
+  Info,
+  MessageCircle,
+  Send,
+  ShieldAlert,
+  Users,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Send, ArrowLeft, Eye, Heart, Clock, MessageCircle, Check, Users, ChevronDown, ChevronUp } from "lucide-react";
-import { supabase } from "@/integrations/supabase/client";
-import { toast } from "sonner";
-import { useNavigate } from "react-router-dom";
-import { useXp } from "@/hooks/use-xp";
-import { XP_REWARDS } from "@/lib/xp";
+import { Textarea } from "@/components/ui/textarea";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import PageTransition from "@/components/PageTransition";
 import { usePushPrompt } from "@/contexts/PushPromptContext";
-import { motion, AnimatePresence } from "framer-motion";
+import { supabase } from "@/integrations/supabase/client";
+import { XP_REWARDS } from "@/lib/xp";
+import { useXp } from "@/hooks/use-xp";
 import { formatTimeAgo } from "@/lib/utils";
 
 const REACTION_MAP: Record<string, { emoji: string; label: string }> = {
@@ -20,7 +36,7 @@ const REACTION_MAP: Record<string, { emoji: string; label: string }> = {
   pray: { emoji: "🙏", label: "Graça" },
   patience: { emoji: "⏳", label: "Paciência" },
   strength: { emoji: "💪", label: "Força" },
-  empathy: { emoji: "🥺", label: "Empatía" },
+  empathy: { emoji: "🥺", label: "Empatia" },
 };
 
 const FEEDBACK_OPTIONS = [
@@ -31,14 +47,73 @@ const FEEDBACK_OPTIONS = [
   { value: "grace_received", label: "Consegui a graça solicitada, obrigado!", emoji: "⭐" },
 ];
 
+type ModerationPolicy = {
+  code: string;
+  label: string;
+  severity: "low" | "medium" | "high";
+};
+
+type SubmitPrayerResponse = {
+  status: "approved" | "needs_review" | "pending_review";
+  prayer_request?: {
+    id: string;
+    title: string | null;
+    status: string;
+    is_anonymous: boolean;
+  };
+  policies?: ModerationPolicy[];
+  risk_score?: number;
+};
+
+type IntercessorSummary = {
+  name: string;
+  city: string;
+  state: string;
+};
+
+type ProfileSummary = {
+  id: string;
+  full_name: string | null;
+  display_name: string | null;
+  show_real_name: boolean;
+  city: string | null;
+  state: string | null;
+};
+
+type PrayerHistoryItem = {
+  id: string;
+  title: string | null;
+  content: string;
+  created_at: string;
+  status: string;
+  feedback: string | null;
+  prayer_count: number;
+  reactions: Record<string, number>;
+  intercessors: IntercessorSummary[];
+};
+
+const isRestrictedPrayer = (status?: string | null) =>
+  status === "pending_review" || status === "policy_violation" || status === "banned";
+
+const getRestrictedMessage = (status?: string | null) => {
+  if (status === "pending_review") {
+    return "Este pedido está em revisão e ainda não está disponível para a comunidade.";
+  }
+
+  return "Este pedido não pode continuar público porque não está de acordo com as políticas do Améns.";
+};
+
 const Submit = () => {
   const navigate = useNavigate();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const { addXp } = useXp();
   const { triggerPushPrompt } = usePushPrompt();
-  
-  // History states
-  const [prayers, setPrayers] = useState<any[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isAnonymous, setIsAnonymous] = useState(false);
+  const [isAnonymousInfoOpen, setIsAnonymousInfoOpen] = useState(false);
+  const [formData, setFormData] = useState({ title: "", content: "", location: "" });
+  const [moderationReview, setModerationReview] = useState<{ policies: ModerationPolicy[]; riskScore: number } | null>(null);
+
+  const [prayers, setPrayers] = useState<PrayerHistoryItem[]>([]);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState<string | null>(null);
   const [sendingFeedback, setSendingFeedback] = useState(false);
@@ -48,7 +123,7 @@ const Submit = () => {
   const fetchHistory = async () => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) return;
-    
+
     setIsLoadingHistory(true);
     try {
       const { data: prayerData, error } = await supabase
@@ -56,49 +131,49 @@ const Submit = () => {
         .select("*")
         .eq("user_id", session.user.id)
         .order("created_at", { ascending: false })
-        .limit(20); // Increased limit for integrated history
-        
+        .limit(20);
+
       if (error) throw error;
       if (!prayerData || prayerData.length === 0) {
         setPrayers([]);
         return;
       }
 
-      const prayerIds = prayerData.map((p) => p.id);
-
-      // Reactions
+      const prayerIds = prayerData.map((prayer) => prayer.id);
       const { data: reactionData } = await supabase
-        .from("prayer_reactions").select("prayer_request_id, reaction_type").in("prayer_request_id", prayerIds);
+        .from("prayer_reactions")
+        .select("prayer_request_id, reaction_type")
+        .in("prayer_request_id", prayerIds);
 
       const reactionsByPrayer: Record<string, Record<string, number>> = {};
-      reactionData?.forEach((r) => {
-        if (!reactionsByPrayer[r.prayer_request_id]) reactionsByPrayer[r.prayer_request_id] = {};
-        reactionsByPrayer[r.prayer_request_id][r.reaction_type] = (reactionsByPrayer[r.prayer_request_id][r.reaction_type] || 0) + 1;
+      reactionData?.forEach((reaction) => {
+        if (!reactionsByPrayer[reaction.prayer_request_id]) reactionsByPrayer[reaction.prayer_request_id] = {};
+        reactionsByPrayer[reaction.prayer_request_id][reaction.reaction_type] =
+          (reactionsByPrayer[reaction.prayer_request_id][reaction.reaction_type] || 0) + 1;
       });
 
-      // Intercessors
       const { data: intercessionData } = await supabase
         .from("prayer_intercessions")
         .select("prayer_request_id, user_id")
         .in("prayer_request_id", prayerIds);
 
-      const intercessorsByPrayer: Record<string, any[]> = {};
+      const intercessorsByPrayer: Record<string, IntercessorSummary[]> = {};
       if (intercessionData && intercessionData.length > 0) {
-        const userIds = [...new Set(intercessionData.map((i) => i.user_id))];
+        const userIds = [...new Set(intercessionData.map((intercession) => intercession.user_id))];
         const { data: profileData } = await supabase
-          .from("profiles" as any)
+          .from("profiles")
           .select("id, full_name, display_name, show_real_name, city, state")
           .in("id", userIds);
 
-        const profileMap = new Map(((profileData || []) as any[]).map((p) => [p.id, p]));
+        const profileMap = new Map(((profileData || []) as ProfileSummary[]).map((profile) => [profile.id, profile]));
 
-        intercessionData.forEach((i) => {
-          if (!intercessorsByPrayer[i.prayer_request_id]) intercessorsByPrayer[i.prayer_request_id] = [];
-          const profile = profileMap.get(i.user_id);
+        intercessionData.forEach((intercession) => {
+          if (!intercessorsByPrayer[intercession.prayer_request_id]) intercessorsByPrayer[intercession.prayer_request_id] = [];
+          const profile = profileMap.get(intercession.user_id);
           const name = profile?.show_real_name
             ? (profile.display_name || profile.full_name?.split(" ")[0] || "Intercessor")
             : "Um intercessor";
-          intercessorsByPrayer[i.prayer_request_id].push({
+          intercessorsByPrayer[intercession.prayer_request_id].push({
             name,
             city: profile?.city || "",
             state: profile?.state || "",
@@ -106,47 +181,15 @@ const Submit = () => {
         });
       }
 
-      setPrayers(prayerData.map((p: any) => ({
-        ...p,
-        reactions: reactionsByPrayer[p.id] || {},
-        intercessors: intercessorsByPrayer[p.id] || [],
-      })));
-    } catch (e) {
-      console.error("Error loading history:", e);
+      setPrayers(prayerData.map((prayer) => ({
+        ...prayer,
+        reactions: reactionsByPrayer[prayer.id] || {},
+        intercessors: intercessorsByPrayer[prayer.id] || [],
+      })) as PrayerHistoryItem[]);
+    } catch (error) {
+      console.error("Error loading history:", error);
     } finally {
       setIsLoadingHistory(false);
-    }
-  };
-
-  const handleFeedback = async (prayerId: string, feedbackValue: string) => {
-    setSendingFeedback(true);
-    try {
-      const { error } = await supabase.from("prayer_requests").update({ feedback: feedbackValue }).eq("id", prayerId);
-      if (error) throw error;
-
-      const { data: intercessions } = await supabase
-        .from("prayer_intercessions").select("user_id").eq("prayer_request_id", prayerId);
-
-      const feedbackLabel = FEEDBACK_OPTIONS.find(f => f.value === feedbackValue)?.label || feedbackValue;
-
-      if (intercessions && intercessions.length > 0) {
-        const prayer = prayers.find(p => p.id === prayerId);
-        const title = prayer?.title || "um pedido";
-        const notifications = intercessions.map(i => ({
-          user_id: i.user_id,
-          prayer_request_id: prayerId,
-          message: `Retorno sobre "${title}": ${feedbackLabel}`,
-        }));
-        await supabase.from("notifications").insert(notifications);
-      }
-
-      setPrayers(prev => prev.map(p => p.id === prayerId ? { ...p, feedback: feedbackValue } : p));
-      setFeedbackOpen(null);
-      toast.success("Feedback enviado! Os intercessores serão notificados.");
-    } catch (e) {
-      toast.error("Erro ao enviar feedback");
-    } finally {
-      setSendingFeedback(false);
     }
   };
 
@@ -158,19 +201,18 @@ const Submit = () => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (!session) {
         navigate("/auth");
-      } else {
-        const city = session.user.user_metadata?.city;
-        const state = session.user.user_metadata?.state;
-        if (city && state) {
-          setFormData(prev => ({ ...prev, location: `${city}, ${state}` }));
-        } else if (city) {
-          setFormData(prev => ({ ...prev, location: city }));
-        }
+        return;
+      }
+
+      const city = session.user.user_metadata?.city;
+      const state = session.user.user_metadata?.state;
+      if (city && state) {
+        setFormData((current) => ({ ...current, location: `${city}, ${state}` }));
+      } else if (city) {
+        setFormData((current) => ({ ...current, location: city }));
       }
     });
   }, [navigate]);
-
-  const [formData, setFormData] = useState({ title: "", content: "", location: "" });
 
   const notifyFriends = async (prayerId: string, title: string) => {
     try {
@@ -179,8 +221,6 @@ const Submit = () => {
 
       const userName = session.user.user_metadata?.full_name || "Um amigo";
       const userFirstName = userName.split(" ")[0];
-
-      // Fetch all friends
       const { data: friendsData } = await supabase
         .from("friendships")
         .select("friend_id")
@@ -188,21 +228,60 @@ const Submit = () => {
 
       if (!friendsData || friendsData.length === 0) return;
 
-      const notifications = friendsData.map(f => ({
-        user_id: f.friend_id,
+      const notifications = friendsData.map((friend) => ({
+        user_id: friend.friend_id,
         prayer_request_id: prayerId,
         message: `🙏 ${userFirstName} acabou de enviar um novo pedido de oração: "${title}"`,
-        is_read: false
+        is_read: false,
       }));
 
       await supabase.from("notifications").insert(notifications);
-    } catch (err) {
-      console.error("Error notifying friends:", err);
+    } catch (error) {
+      console.error("Error notifying friends:", error);
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleFeedback = async (prayerId: string, feedbackValue: string) => {
+    const prayer = prayers.find((item) => item.id === prayerId);
+    if (isRestrictedPrayer(prayer?.status)) {
+      toast.error("Este pedido está com interações bloqueadas.");
+      return;
+    }
+
+    setSendingFeedback(true);
+    try {
+      const { error } = await supabase.from("prayer_requests").update({ feedback: feedbackValue }).eq("id", prayerId);
+      if (error) throw error;
+
+      const { data: intercessions } = await supabase
+        .from("prayer_intercessions")
+        .select("user_id")
+        .eq("prayer_request_id", prayerId);
+
+      const feedbackLabel = FEEDBACK_OPTIONS.find((feedback) => feedback.value === feedbackValue)?.label || feedbackValue;
+
+      if (intercessions && intercessions.length > 0) {
+        const title = prayer?.title || "um pedido";
+        const notifications = intercessions.map((intercession) => ({
+          user_id: intercession.user_id,
+          prayer_request_id: prayerId,
+          message: `Retorno sobre "${title}": ${feedbackLabel}`,
+        }));
+        await supabase.from("notifications").insert(notifications);
+      }
+
+      setPrayers((current) => current.map((item) => item.id === prayerId ? { ...item, feedback: feedbackValue } : item));
+      setFeedbackOpen(null);
+      toast.success("Feedback enviado! Os intercessores serão notificados.");
+    } catch (error) {
+      console.error("Feedback error:", error);
+      toast.error("Erro ao enviar feedback");
+    } finally {
+      setSendingFeedback(false);
+    }
+  };
+
+  const submitPrayerRequest = async (confirmReview = false) => {
     if (!formData.content.trim()) {
       toast.error("Por favor, descreva seu pedido de oração");
       return;
@@ -211,29 +290,50 @@ const Submit = () => {
       toast.error("O título do pedido deve ter pelo menos 5 letras");
       return;
     }
+
     setIsSubmitting(true);
     try {
       const { data: { session } } = await supabase.auth.getSession();
-      const fullName = session?.user?.user_metadata?.full_name || "Anônimo";
-      const firstName = fullName.split(' ')[0];
-      
-      const { data, error } = await supabase.from('prayer_requests').insert([{
-        title: formData.title.trim(),
-        content: formData.content.trim(),
-        location: formData.location.trim() || null,
-        prayer_count: 0,
-        user_id: session?.user?.id,
-        author_name: firstName,
-      }]).select().single();
-
-      if (error) throw error;
-      
-      if (data) {
-        await notifyFriends(data.id, data.title);
+      if (!session) {
+        navigate("/auth");
+        return;
       }
 
-      // Daily XP gate — award submit XP only once per day
-      const userId = session?.user?.id;
+      const { data, error } = await supabase.functions.invoke<SubmitPrayerResponse>("submit-prayer-request", {
+        body: {
+          title: formData.title.trim(),
+          content: formData.content.trim(),
+          location: formData.location.trim() || null,
+          is_anonymous: isAnonymous,
+          confirm_review: confirmReview,
+        },
+      });
+
+      if (error) throw error;
+
+      if (data?.status === "needs_review") {
+        setModerationReview({
+          policies: data.policies || [],
+          riskScore: data.risk_score || 0,
+        });
+        toast.info("Revise o aviso antes de enviar seu pedido.");
+        return;
+      }
+
+      if (data?.status === "pending_review") {
+        toast.success("Seu pedido foi enviado para revisão. Avisaremos quando houver uma decisão.");
+        setFormData({ title: "", content: "", location: "" });
+        setIsAnonymous(false);
+        setModerationReview(null);
+        fetchHistory();
+        return;
+      }
+
+      if (data?.prayer_request && !isAnonymous) {
+        await notifyFriends(data.prayer_request.id, data.prayer_request.title || formData.title.trim());
+      }
+
+      const userId = session.user.id;
       const today = new Date().toISOString().split("T")[0];
       const submitXpKey = `amens_submit_xp_${userId}_${today}`;
       if (userId && !localStorage.getItem(submitXpKey)) {
@@ -243,20 +343,28 @@ const Submit = () => {
       } else {
         toast.success("Pedido enviado com sucesso!");
       }
+
       setFormData({ title: "", content: "", location: "" });
-      
-      // Trigger push prompt
+      setIsAnonymous(false);
+      setModerationReview(null);
+
       setTimeout(() => {
-         triggerPushPrompt("Saiba quando alguém orar por seu pedido, autorize as notificações");
+        triggerPushPrompt("Saiba quando alguém orar por seu pedido, autorize as notificações");
       }, 800);
 
       setTimeout(() => navigate("/"), 3000);
-    } catch (error: any) {
-      console.error('Error submitting prayer request:', error);
-      toast.error(`Erro técnico: ${error.message || JSON.stringify(error)}`);
+    } catch (error: unknown) {
+      console.error("Error submitting prayer request:", error);
+      const errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+      toast.error(`Erro técnico: ${errorMessage}`);
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    submitPrayerRequest(false);
   };
 
   return (
@@ -282,22 +390,101 @@ const Submit = () => {
               <form onSubmit={handleSubmit} className="space-y-6">
                 <div>
                   <div className="flex items-center justify-between mb-2">
-                    <Label htmlFor="title" className="text-base">Título (Opcional)</Label>
+                    <Label htmlFor="title" className="text-base">Título *</Label>
                     <div className="w-10 h-10 overflow-visible relative flex-shrink-0">
-                      <img 
-                        src="/enviar_pergaminho_3d.png" 
-                        alt="Pergaminho solitário" 
-                        className={`w-full h-full object-contain transition-all duration-500 ${isSubmitting ? 'drop-shadow-[0_0_25px_rgba(255,215,0,1)] brightness-125 scale-110' : 'drop-shadow-sm'}`} 
+                      <img
+                        src="/enviar_pergaminho_3d.png"
+                        alt="Pergaminho solitário"
+                        className={`w-full h-full object-contain transition-all duration-500 ${isSubmitting ? "drop-shadow-[0_0_25px_rgba(255,215,0,1)] brightness-125 scale-110" : "drop-shadow-sm"}`}
                       />
                     </div>
                   </div>
-                  <Input id="title" placeholder="Ex: Cura para meu filho Miguel" value={formData.title} onChange={(e) => setFormData({ ...formData, title: e.target.value })} maxLength={100} />
+                  <Input
+                    id="title"
+                    placeholder="Ex: Cura para meu filho Miguel"
+                    value={formData.title}
+                    onChange={(event) => {
+                      setFormData({ ...formData, title: event.target.value });
+                      setModerationReview(null);
+                    }}
+                    maxLength={100}
+                  />
                 </div>
+
                 <div>
                   <Label htmlFor="content" className="text-base">Seu Pedido de Oração *</Label>
-                  <Textarea id="content" placeholder="Descreva seu pedido de oração com detalhes..." value={formData.content} onChange={(e) => setFormData({ ...formData, content: e.target.value })} className="mt-2 min-h-[180px]" required maxLength={1000} />
+                  <Textarea
+                    id="content"
+                    placeholder="Descreva seu pedido de oração com detalhes..."
+                    value={formData.content}
+                    onChange={(event) => {
+                      setFormData({ ...formData, content: event.target.value });
+                      setModerationReview(null);
+                    }}
+                    className="mt-2 min-h-[180px]"
+                    required
+                    maxLength={1000}
+                  />
                   <p className="text-sm text-muted-foreground mt-1">{formData.content.length}/1000 caracteres</p>
                 </div>
+
+                <div className="flex items-center justify-between gap-3 rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      id="is-anonymous"
+                      checked={isAnonymous}
+                      onCheckedChange={(checked) => setIsAnonymous(checked === true)}
+                    />
+                    <Label htmlFor="is-anonymous" className="text-sm font-semibold cursor-pointer">
+                      Enviar como anônimo
+                    </Label>
+                  </div>
+                  <Popover open={isAnonymousInfoOpen} onOpenChange={setIsAnonymousInfoOpen}>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        className="rounded-full p-1 text-primary hover:bg-primary/10"
+                        aria-label="Entenda o envio anônimo"
+                        onMouseEnter={() => setIsAnonymousInfoOpen(true)}
+                        onFocus={() => setIsAnonymousInfoOpen(true)}
+                      >
+                        <Info className="w-4 h-4" />
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="max-w-xs text-sm leading-relaxed">
+                      Seu nome e foto não aparecerão para quem rezar por este pedido. Você ainda poderá receber reações e enviar retornos, mas sua identidade ficará preservada para a comunidade.
+                    </PopoverContent>
+                  </Popover>
+                </div>
+
+                {moderationReview && (
+                  <Alert className="border-amber-300 bg-amber-50 text-amber-950">
+                    <ShieldAlert className="w-4 h-4 text-amber-700" />
+                    <AlertTitle>Seu pedido precisa de atenção</AlertTitle>
+                    <AlertDescription className="space-y-3">
+                      <p>
+                        Encontramos possíveis informações sensíveis ou conteúdo que pode não estar de acordo com as políticas do Améns.
+                        Você pode ajustar o texto antes de enviar ou encaminhar o pedido para revisão.
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {moderationReview.policies.map((policy) => (
+                          <span key={policy.code} className="rounded-full bg-white/80 px-2.5 py-1 text-[11px] font-bold text-amber-800 border border-amber-200">
+                            {policy.label}
+                          </span>
+                        ))}
+                      </div>
+                      <div className="flex flex-col sm:flex-row gap-2 pt-1">
+                        <Button type="button" variant="outline" onClick={() => setModerationReview(null)} className="border-amber-300 text-amber-900 hover:bg-amber-100">
+                          Editar pedido
+                        </Button>
+                        <Button type="button" onClick={() => submitPrayerRequest(true)} disabled={isSubmitting} className="bg-amber-600 text-white hover:bg-amber-700 border-0">
+                          Enviar para revisão
+                        </Button>
+                      </div>
+                    </AlertDescription>
+                  </Alert>
+                )}
+
                 <Button type="submit" disabled={isSubmitting} size="lg" className="w-full gradient-divine text-black hover:opacity-90 font-bold">
                   <Send className="w-4 h-4 mr-2" />
                   {isSubmitting ? "Enviando..." : "Enviar Pedido"}
@@ -306,135 +493,145 @@ const Submit = () => {
             </Card>
           </motion.div>
 
-          {/* History Section */}
           <div className="max-w-2xl mx-auto mt-16 pb-20 px-2">
-             {!showHistory ? (
-                <div className="text-center">
-                   <Button 
-                     variant="ghost" 
-                     onClick={() => setShowHistory(true)}
-                     className="text-black hover:text-primary text-[11px] uppercase tracking-widest font-black py-8 bg-primary/5 rounded-[2rem] border border-dashed border-primary/20 w-full hover:bg-primary/10 transition-all font-serif italic"
-                   >
-                     <Clock className="w-4 h-4 mr-2" />
-                     Ver meus pedidos anteriores
-                   </Button>
-                </div>
-             ) : (
-                <motion.div 
-                   initial={{ opacity: 0, scale: 0.95 }}
-                   animate={{ opacity: 1, scale: 1 }}
-                   className="space-y-6"
+            {!showHistory ? (
+              <div className="text-center">
+                <Button
+                  variant="ghost"
+                  onClick={() => setShowHistory(true)}
+                  className="text-black hover:text-primary text-[11px] uppercase tracking-widest font-black py-8 bg-primary/5 rounded-[2rem] border border-dashed border-primary/20 w-full hover:bg-primary/10 transition-all font-serif italic"
                 >
-                   <div className="flex items-center justify-between mb-4">
-                      <div className="flex items-center gap-3">
-                         <Clock className="w-5 h-5 text-primary opacity-60" />
-                         <h2 className="text-xl font-bold text-foreground opacity-80 uppercase tracking-widest text-[14px]">Pedidos Recentes</h2>
-                      </div>
-                      <Button variant="ghost" size="sm" onClick={() => setShowHistory(false)} className="text-[10px] uppercase font-bold text-muted-foreground">Ocultar</Button>
-                   </div>
+                  <Clock className="w-4 h-4 mr-2" />
+                  Ver meus pedidos anteriores
+                </Button>
+              </div>
+            ) : (
+              <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} className="space-y-6">
+                <div className="flex items-center justify-between mb-4">
+                  <div className="flex items-center gap-3">
+                    <Clock className="w-5 h-5 text-primary opacity-60" />
+                    <h2 className="text-xl font-bold text-foreground opacity-80 uppercase tracking-widest text-[14px]">Pedidos Recentes</h2>
+                  </div>
+                  <Button variant="ghost" size="sm" onClick={() => setShowHistory(false)} className="text-[10px] uppercase font-bold text-muted-foreground">Ocultar</Button>
+                </div>
 
-                   {isLoadingHistory ? (
-                     <div className="text-center py-6 opacity-40">
-                        <div className="animate-spin w-5 h-5 border-2 border-primary border-t-transparent rounded-full mx-auto mb-2" />
-                        <p className="text-xs">Carregando histórico...</p>
-                     </div>
-                   ) : prayers.length === 0 ? (
-                     <p className="text-center text-sm text-muted-foreground py-8 border border-dashed border-primary/10 rounded-3xl">
-                       Você ainda não enviou nenhum pedido.
-                     </p>
-                   ) : (
-                     <div className="space-y-6">
-                        {prayers.map((prayer, i) => (
-                          <motion.div 
-                            key={prayer.id} 
-                            initial={{ opacity: 0, scale: 0.98 }} 
-                            animate={{ opacity: 1, scale: 1 }} 
-                            transition={{ delay: i * 0.1 }}
-                          >
-                            <Card className="p-6 soft-shadow border-primary/5 bg-white/70 backdrop-blur-sm rounded-[2rem]">
-                              <div className="mb-4">
-                                <div className="flex justify-between items-start mb-2">
-                                  {prayer.title && <h3 className="text-base font-bold text-foreground">{prayer.title}</h3>}
-                                  <span className="text-[10px] bg-primary/5 px-2 py-1 rounded-full text-primary font-bold">{formatTimeAgo(prayer.created_at)}</span>
+                {isLoadingHistory ? (
+                  <div className="text-center py-6 opacity-40">
+                    <div className="animate-spin w-5 h-5 border-2 border-primary border-t-transparent rounded-full mx-auto mb-2" />
+                    <p className="text-xs">Carregando histórico...</p>
+                  </div>
+                ) : prayers.length === 0 ? (
+                  <p className="text-center text-sm text-muted-foreground py-8 border border-dashed border-primary/10 rounded-3xl">
+                    Você ainda não enviou nenhum pedido.
+                  </p>
+                ) : (
+                  <div className="space-y-6">
+                    {prayers.map((prayer, index) => {
+                      const isRestricted = isRestrictedPrayer(prayer.status);
+                      const reactionsCount = Object.values(prayer.reactions).reduce((total, value) => total + value, 0);
+
+                      return (
+                        <motion.div
+                          key={prayer.id}
+                          initial={{ opacity: 0, scale: 0.98 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          transition={{ delay: index * 0.1 }}
+                        >
+                          <Card className={`p-6 soft-shadow bg-white/70 backdrop-blur-sm rounded-[2rem] ${isRestricted ? "border-amber-200" : "border-primary/5"}`}>
+                            <div className="mb-4">
+                              <div className="flex justify-between items-start gap-3 mb-2">
+                                {prayer.title && <h3 className="text-base font-bold text-foreground">{prayer.title}</h3>}
+                                <span className="text-[10px] bg-primary/5 px-2 py-1 rounded-full text-primary font-bold">{formatTimeAgo(prayer.created_at)}</span>
+                              </div>
+                              {isRestricted ? (
+                                <div className="rounded-2xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                                  <p className="font-bold mb-1">Conteúdo indisponível</p>
+                                  <p>{getRestrictedMessage(prayer.status)}</p>
                                 </div>
+                              ) : (
                                 <p className="text-sm text-muted-foreground leading-relaxed line-clamp-2">{prayer.content}</p>
-                              </div>
-                              
-                              <div className="flex items-center gap-4 text-[11px] text-muted-foreground mb-4">
-                                 <div className="flex items-center gap-1"><Eye className="w-3.5 h-3.5" /> <span>{prayer.prayer_count}</span></div>
-                                 <div className="flex items-center gap-1"><Heart className="w-3.5 h-3.5" /> <span>{Object.values(prayer.reactions as object).reduce((a: any, b: any) => a + b, 0)}</span></div>
-                              </div>
+                              )}
+                            </div>
 
-                              {/* Intercessors List */}
-                              {prayer.intercessors.length > 0 && (
-                                <div className="mb-4 bg-primary/5 rounded-2xl p-3">
-                                  <button
-                                    onClick={() => setIntercessorsOpen(intercessorsOpen === prayer.id ? null : prayer.id)}
-                                    className="flex items-center gap-2 text-[10px] font-black text-primary/70 uppercase tracking-wider w-full text-left"
-                                  >
-                                    <Users className="w-3.5 h-3.5" />
-                                    {prayer.intercessors.length} {prayer.intercessors.length === 1 ? "pessoa orou" : "pessoas oraram"} por você
-                                    {intercessorsOpen === prayer.id ? <ChevronUp className="w-3 h-3 ml-auto" /> : <ChevronDown className="w-3 h-3 ml-auto" />}
-                                  </button>
+                            <div className="flex items-center gap-4 text-[11px] text-muted-foreground mb-4">
+                              <div className="flex items-center gap-1"><Eye className="w-3.5 h-3.5" /> <span>{prayer.prayer_count}</span></div>
+                              <div className="flex items-center gap-1"><Heart className="w-3.5 h-3.5" /> <span>{reactionsCount}</span></div>
+                            </div>
 
-                                  <AnimatePresence>
-                                    {intercessorsOpen === prayer.id && (
-                                      <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden">
-                                        <div className="mt-2 flex flex-wrap gap-1.5">
-                                          {prayer.intercessors.map((int: any, idx: number) => (
-                                            <span key={idx} className="bg-white/50 px-2 py-1 rounded-full text-[9px] font-bold text-stone-600 border border-primary/5">
-                                              🙏 {int.name}
-                                            </span>
-                                          ))}
-                                        </div>
-                                      </motion.div>
-                                    )}
-                                  </AnimatePresence>
+                            {!isRestricted && prayer.intercessors.length > 0 && (
+                              <div className="mb-4 bg-primary/5 rounded-2xl p-3">
+                                <button
+                                  onClick={() => setIntercessorsOpen(intercessorsOpen === prayer.id ? null : prayer.id)}
+                                  className="flex items-center gap-2 text-[10px] font-black text-primary/70 uppercase tracking-wider w-full text-left"
+                                >
+                                  <Users className="w-3.5 h-3.5" />
+                                  {prayer.intercessors.length} {prayer.intercessors.length === 1 ? "pessoa orou" : "pessoas oraram"} por você
+                                  {intercessorsOpen === prayer.id ? <ChevronUp className="w-3 h-3 ml-auto" /> : <ChevronDown className="w-3 h-3 ml-auto" />}
+                                </button>
+
+                                <AnimatePresence>
+                                  {intercessorsOpen === prayer.id && (
+                                    <motion.div initial={{ opacity: 0, height: 0 }} animate={{ opacity: 1, height: "auto" }} exit={{ opacity: 0, height: 0 }} className="overflow-hidden">
+                                      <div className="mt-2 flex flex-wrap gap-1.5">
+                                        {prayer.intercessors.map((intercessor, intercessorIndex) => (
+                                          <span key={intercessorIndex} className="bg-white/50 px-2 py-1 rounded-full text-[9px] font-bold text-stone-600 border border-primary/5">
+                                            🙏 {intercessor.name}
+                                          </span>
+                                        ))}
+                                      </div>
+                                    </motion.div>
+                                  )}
+                                </AnimatePresence>
+                              </div>
+                            )}
+
+                            <div className="pt-3 border-t border-primary/5">
+                              {isRestricted ? (
+                                <div className="flex items-center gap-2 text-[11px] font-bold text-amber-700">
+                                  <ShieldAlert className="w-3.5 h-3.5" />
+                                  <span>Interações bloqueadas para este pedido.</span>
+                                </div>
+                              ) : prayer.feedback ? (
+                                <div className="flex items-center gap-2 text-[11px] font-bold text-primary">
+                                  <Check className="w-3.5 h-3.5" />
+                                  <span>Seu retorno: {FEEDBACK_OPTIONS.find((feedback) => feedback.value === prayer.feedback)?.emoji} {FEEDBACK_OPTIONS.find((feedback) => feedback.value === prayer.feedback)?.label}</span>
+                                </div>
+                              ) : (
+                                <div>
+                                  {feedbackOpen === prayer.id ? (
+                                    <div className="space-y-2 py-2">
+                                      <p className="text-[10px] font-black text-muted-foreground uppercase mb-2 tracking-widest">Dê um retorno aos intercessores:</p>
+                                      <div className="grid grid-cols-1 gap-2">
+                                        {FEEDBACK_OPTIONS.map((option) => (
+                                          <button
+                                            key={option.value}
+                                            disabled={sendingFeedback}
+                                            onClick={() => handleFeedback(prayer.id, option.value)}
+                                            className="text-left px-3 py-2 rounded-xl border border-primary/10 hover:bg-primary/5 text-xs flex items-center gap-2 transition-all"
+                                          >
+                                            <span>{option.emoji}</span>
+                                            <span className="text-stone-700">{option.label}</span>
+                                          </button>
+                                        ))}
+                                      </div>
+                                      <Button variant="ghost" size="sm" onClick={() => setFeedbackOpen(null)} className="h-7 text-[10px] mt-1">Cancelar</Button>
+                                    </div>
+                                  ) : (
+                                    <Button variant="outline" size="sm" onClick={() => setFeedbackOpen(prayer.id)} className="h-8 rounded-full text-[10px] font-bold border-primary/10 text-primary">
+                                      <MessageCircle className="w-3 h-3 mr-1.5" /> Dar Retorno
+                                    </Button>
+                                  )}
                                 </div>
                               )}
-
-                              {/* Feedback Section */}
-                              <div className="pt-3 border-t border-primary/5">
-                                {prayer.feedback ? (
-                                  <div className="flex items-center gap-2 text-[11px] font-bold text-primary">
-                                    <Check className="w-3.5 h-3.5" />
-                                    <span>Seu retorno: {FEEDBACK_OPTIONS.find(f => f.value === prayer.feedback)?.emoji} {FEEDBACK_OPTIONS.find(f => f.value === prayer.feedback)?.label}</span>
-                                  </div>
-                                ) : (
-                                  <div>
-                                     {feedbackOpen === prayer.id ? (
-                                       <div className="space-y-2 py-2">
-                                          <p className="text-[10px] font-black text-muted-foreground uppercase mb-2 tracking-widest">Dê um retorno aos intercessores:</p>
-                                          <div className="grid grid-cols-1 gap-2">
-                                             {FEEDBACK_OPTIONS.map(option => (
-                                               <button 
-                                                 key={option.value} 
-                                                 disabled={sendingFeedback}
-                                                 onClick={() => handleFeedback(prayer.id, option.value)}
-                                                 className="text-left px-3 py-2 rounded-xl border border-primary/10 hover:bg-primary/5 text-xs flex items-center gap-2 transition-all"
-                                               >
-                                                 <span>{option.emoji}</span>
-                                                 <span className="text-stone-700">{option.label}</span>
-                                               </button>
-                                             ))}
-                                          </div>
-                                          <Button variant="ghost" size="sm" onClick={() => setFeedbackOpen(null)} className="h-7 text-[10px] mt-1">Cancelar</Button>
-                                       </div>
-                                     ) : (
-                                       <Button variant="outline" size="sm" onClick={() => setFeedbackOpen(prayer.id)} className="h-8 rounded-full text-[10px] font-bold border-primary/10 text-primary">
-                                          <MessageCircle className="w-3 h-3 mr-1.5" /> Dar Retorno
-                                       </Button>
-                                     )}
-                                  </div>
-                                )}
-                              </div>
-                            </Card>
-                          </motion.div>
-                        ))}
-                     </div>
-                   )}
-                </motion.div>
-             )}
+                            </div>
+                          </Card>
+                        </motion.div>
+                      );
+                    })}
+                  </div>
+                )}
+              </motion.div>
+            )}
           </div>
         </div>
       </div>

--- a/supabase/functions/submit-prayer-request/index.ts
+++ b/supabase/functions/submit-prayer-request/index.ts
@@ -1,0 +1,398 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
+};
+
+type ModerationPolicy = {
+  code: string;
+  label: string;
+  severity: "low" | "medium" | "high";
+};
+
+type ModerationResult = {
+  decision: "approved" | "needs_review";
+  riskScore: number;
+  policies: ModerationPolicy[];
+  normalizedContent: string;
+};
+
+const POLICY_WEIGHTS: Record<ModerationPolicy["severity"], number> = {
+  low: 1,
+  medium: 3,
+  high: 5,
+};
+
+const addPolicy = (
+  policies: ModerationPolicy[],
+  seen: Set<string>,
+  policy: ModerationPolicy,
+) => {
+  if (seen.has(policy.code)) return;
+  seen.add(policy.code);
+  policies.push(policy);
+};
+
+const normalizeText = (value: string) => {
+  const leetMap: Record<string, string> = {
+    "@": "a",
+    "4": "a",
+    "0": "o",
+    "1": "i",
+    "!": "i",
+    "3": "e",
+    "$": "s",
+    "5": "s",
+    "7": "t",
+  };
+
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[@401!3$57]/g, (char) => leetMap[char] ?? char)
+    .replace(/([a-z])[._-]+(?=[a-z])/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const COMMON_FIRST_NAMES = new Set([
+  "ana",
+  "antonio",
+  "bruno",
+  "carlos",
+  "daniel",
+  "danilo",
+  "eduardo",
+  "fernanda",
+  "fernando",
+  "gabriel",
+  "joao",
+  "jose",
+  "juliana",
+  "lucas",
+  "luiz",
+  "maria",
+  "marcos",
+  "mateus",
+  "miguel",
+  "paulo",
+  "pedro",
+  "rafael",
+  "roberto",
+  "vinicius",
+]);
+
+const COMMON_SURNAMES = new Set([
+  "almeida",
+  "alves",
+  "barbosa",
+  "costa",
+  "dias",
+  "ferreira",
+  "gomes",
+  "lima",
+  "martins",
+  "oliveira",
+  "pereira",
+  "rocha",
+  "santos",
+  "silva",
+  "souza",
+]);
+
+const NAME_STOPWORDS = new Set([
+  "aos",
+  "com",
+  "das",
+  "dos",
+  "ela",
+  "ele",
+  "estou",
+  "filha",
+  "filho",
+  "irma",
+  "irmao",
+  "meu",
+  "minha",
+  "para",
+  "pela",
+  "pelo",
+  "por",
+  "que",
+  "rezem",
+  "uma",
+]);
+
+const hasFullName = (text: string) => {
+  const words = text.match(/\b[a-z]{3,}\b/g) || [];
+
+  for (let index = 0; index < words.length - 1; index += 1) {
+    const first = words[index];
+    const second = words[index + 1];
+    const third = words[index + 2];
+
+    if (NAME_STOPWORDS.has(first) || NAME_STOPWORDS.has(second)) continue;
+
+    if (
+      COMMON_FIRST_NAMES.has(first) &&
+      (COMMON_FIRST_NAMES.has(second) || COMMON_SURNAMES.has(second))
+    ) {
+      return true;
+    }
+
+    if (
+      third &&
+      !NAME_STOPWORDS.has(third) &&
+      COMMON_FIRST_NAMES.has(first)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const moderateContent = (title: string, content: string, isAnonymous: boolean): ModerationResult => {
+  const normalizedContent = normalizeText(`${title} ${content}`);
+  const compact = normalizedContent.replace(/\D/g, "");
+  const policies: ModerationPolicy[] = [];
+  const seen = new Set<string>();
+
+  if (/\b[\w.-]+@[\w.-]+\.[a-z]{2,}\b/.test(content.toLowerCase())) {
+    addPolicy(policies, seen, {
+      code: "email",
+      label: "e-mail ou contato pessoal",
+      severity: "medium",
+    });
+  }
+
+  if (/(https?:\/\/|www\.|\.com\b|\.com\.br\b|\.net\b|\.org\b)/i.test(content)) {
+    addPolicy(policies, seen, {
+      code: "external_link",
+      label: "link externo",
+      severity: "medium",
+    });
+  }
+
+  if (/(cpf|rg|documento|identidade)\b/.test(normalizedContent) || /\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/.test(content)) {
+    addPolicy(policies, seen, {
+      code: "document",
+      label: "documento pessoal",
+      severity: "high",
+    });
+  }
+
+  if (/(pix|chave pix|banco|agencia|conta bancaria|dados bancarios)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "financial_data",
+      label: "dados financeiros ou chave PIX",
+      severity: "high",
+    });
+  }
+
+  if (/(doacao|doar|vaquinha|transferencia|deposito|dinheiro|pagar boleto|ajuda financeira)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "financial_request",
+      label: "pedido financeiro",
+      severity: "high",
+    });
+  }
+
+  if (compact.length >= 10 && /(?:\d[\s().-]*){10,}/.test(content)) {
+    addPolicy(policies, seen, {
+      code: "phone",
+      label: "telefone ou contato pessoal",
+      severity: "high",
+    });
+  }
+
+  if (/(rua|avenida|av\.|travessa|alameda|rodovia|numero|nº|apto|apartamento|bloco)\s+[a-z0-9]/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "address",
+      label: "endereço ou localização específica",
+      severity: "high",
+    });
+  }
+
+  if (hasFullName(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "full_name",
+      label: "nome completo ou identificação pessoal",
+      severity: "medium",
+    });
+  }
+
+  if (/(idiota|imbecil|burro|maldito|desgracado|lixo|vagabundo)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "offense",
+      label: "ofensa ou linguagem agressiva",
+      severity: "medium",
+    });
+  }
+
+  if (/(matar|morte a|espancar|agredir|ameacar|vinganca|vou acabar com)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "violence",
+      label: "ameaça ou violência explícita",
+      severity: "high",
+    });
+  }
+
+  if (/(racista|nazista|preto sujo|viado|bicha|traveco|macaco|judeu sujo)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "hate",
+      label: "discurso de ódio ou preconceito",
+      severity: "high",
+    });
+  }
+
+  if (/(sexo explicito|pornografia|nudez|abuso sexual|estupro|menor de idade)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "sexual_content",
+      label: "conteúdo sexual explícito",
+      severity: "high",
+    });
+  }
+
+  if (/(vou me matar|quero me matar|tirar minha vida|suicidio|automutilacao|me cortar)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "self_harm",
+      label: "automutilação explícita",
+      severity: "high",
+    });
+  }
+
+  if (isAnonymous && /(assinado|me chamo|meu nome e|sou de|moro em)/.test(normalizedContent)) {
+    addPolicy(policies, seen, {
+      code: "anonymous_identity",
+      label: "informação que pode revelar sua identidade",
+      severity: "medium",
+    });
+  }
+
+  const riskScore = policies.reduce((score, policy) => score + POLICY_WEIGHTS[policy.severity], 0);
+
+  return {
+    decision: riskScore >= 3 ? "needs_review" : "approved",
+    riskScore,
+    policies,
+    normalizedContent,
+  };
+};
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const authorization = req.headers.get("Authorization");
+    if (!authorization) {
+      return jsonResponse({ error: "Missing authorization header" }, 401);
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+    const userClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authorization } },
+    });
+    const serviceClient = createClient(supabaseUrl, serviceRoleKey);
+
+    const { data: userData, error: userError } = await userClient.auth.getUser();
+    if (userError || !userData.user) {
+      return jsonResponse({ error: "Unauthorized" }, 401);
+    }
+
+    const {
+      title = "",
+      content = "",
+      location = "",
+      is_anonymous = false,
+      confirm_review = false,
+    } = await req.json();
+
+    const cleanTitle = String(title).trim();
+    const cleanContent = String(content).trim();
+    const cleanLocation = String(location).trim();
+    const isAnonymous = Boolean(is_anonymous);
+
+    if (cleanTitle.length < 5) {
+      return jsonResponse({ error: "Title must have at least 5 characters" }, 400);
+    }
+
+    if (!cleanContent) {
+      return jsonResponse({ error: "Content is required" }, 400);
+    }
+
+    if (cleanContent.length > 1000) {
+      return jsonResponse({ error: "Content is too long" }, 400);
+    }
+
+    const moderation = moderateContent(cleanTitle, cleanContent, isAnonymous);
+    if (moderation.decision === "needs_review" && !confirm_review) {
+      return jsonResponse({
+        status: "needs_review",
+        policies: moderation.policies,
+        risk_score: moderation.riskScore,
+      });
+    }
+
+    const metadata = userData.user.user_metadata ?? {};
+    const fullName = typeof metadata.full_name === "string" ? metadata.full_name : "";
+    const firstName = fullName.split(" ")[0] || "Anônimo";
+    const requestStatus = moderation.decision === "needs_review" ? "pending_review" : "active";
+
+    const { data: prayerRequest, error: insertError } = await serviceClient
+      .from("prayer_requests")
+      .insert({
+        title: cleanTitle,
+        content: cleanContent,
+        location: isAnonymous ? null : cleanLocation || null,
+        prayer_count: 0,
+        user_id: userData.user.id,
+        author_name: isAnonymous ? null : firstName,
+        is_anonymous: isAnonymous,
+        status: requestStatus,
+      })
+      .select("id, title, status, is_anonymous")
+      .single();
+
+    if (insertError) throw insertError;
+
+    await serviceClient.from("prayer_moderation_reviews").insert({
+      prayer_request_id: prayerRequest.id,
+      user_id: userData.user.id,
+      original_title: cleanTitle,
+      original_content: cleanContent,
+      normalized_content: moderation.normalizedContent,
+      detected_policies: moderation.policies,
+      risk_score: moderation.riskScore,
+      decision: requestStatus,
+    });
+
+    return jsonResponse({
+      status: requestStatus === "active" ? "approved" : "pending_review",
+      prayer_request: prayerRequest,
+      policies: moderation.policies,
+      risk_score: moderation.riskScore,
+    });
+  } catch (error) {
+    console.error("submit-prayer-request error:", error);
+    return jsonResponse(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      500,
+    );
+  }
+});

--- a/supabase/migrations/20260512120000_prayer_request_privacy_moderation.sql
+++ b/supabase/migrations/20260512120000_prayer_request_privacy_moderation.sql
@@ -1,0 +1,70 @@
+-- Prayer request privacy and local moderation support.
+
+ALTER TABLE public.prayer_requests
+  ADD COLUMN IF NOT EXISTS author_name text,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'active',
+  ADD COLUMN IF NOT EXISTS is_anonymous boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.prayer_requests
+  DROP CONSTRAINT IF EXISTS prayer_requests_status_check;
+
+ALTER TABLE public.prayer_requests
+  ADD CONSTRAINT prayer_requests_status_check
+  CHECK (status IN ('active', 'completed', 'pending_review', 'policy_violation', 'banned'));
+
+CREATE TABLE IF NOT EXISTS public.prayer_moderation_reviews (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  prayer_request_id uuid REFERENCES public.prayer_requests(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  original_title text,
+  original_content text NOT NULL,
+  normalized_content text NOT NULL,
+  detected_policies jsonb NOT NULL DEFAULT '[]'::jsonb,
+  risk_score integer NOT NULL DEFAULT 0,
+  decision text NOT NULL DEFAULT 'approved',
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.prayer_moderation_reviews ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "No public moderation review access" ON public.prayer_moderation_reviews;
+CREATE POLICY "No public moderation review access"
+  ON public.prayer_moderation_reviews
+  FOR SELECT
+  TO authenticated
+  USING (false);
+
+CREATE TRIGGER update_prayer_moderation_reviews_updated_at
+  BEFORE UPDATE ON public.prayer_moderation_reviews
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE OR REPLACE FUNCTION public.notify_prayer_policy_violation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.status = 'policy_violation'
+    AND (OLD.status IS DISTINCT FROM NEW.status)
+    AND NEW.user_id IS NOT NULL THEN
+    INSERT INTO public.notifications (user_id, prayer_request_id, message, type)
+    VALUES (
+      NEW.user_id,
+      NEW.id,
+      'Seu pedido foi revisado e não poderá continuar público porque não está de acordo com as políticas do Améns.',
+      'prayer_policy_violation'
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS notify_prayer_policy_violation_trigger ON public.prayer_requests;
+CREATE TRIGGER notify_prayer_policy_violation_trigger
+  AFTER UPDATE OF status ON public.prayer_requests
+  FOR EACH ROW
+  EXECUTE FUNCTION public.notify_prayer_policy_violation();


### PR DESCRIPTION
## Summary

Adds per-prayer-request anonymity and local moderation for prayer request submissions.

## Changes

- Adds `submit-prayer-request` Supabase Edge Function.
- Routes prayer request creation through the Edge Function instead of direct client insert.
- Adds local moderation checks for:
  - full names / personal identification
  - email/contact info
  - phone numbers
  - CPF/RG/documents
  - likely addresses
  - PIX/banking data
  - financial requests
  - external links
  - offensive language
  - explicit threats/violence
  - hate/prejudice
  - explicit sexual content
  - explicit self-harm
  - identity-revealing text in anonymous requests
- Adds per-request anonymity via `is_anonymous`.
- Hides anonymous author name/avatar from intercessors.
- Adds moderation statuses: `pending_review`, `policy_violation`.
- Blocks reactions, feedback, re-pray, and new interactions for restricted requests.
- Hides restricted request content in requester/intercessor history.
- Adds moderation audit table `prayer_moderation_reviews`.
- Adds trigger to notify requesters when a request is marked as `policy_violation`.
- Updates app feature context documentation.

## Manual Review Queries

List pending review requests:

```sql
SELECT
  pr.id,
  pr.title,
  pr.content,
  pr.status,
  pr.user_id,
  pmr.detected_policies,
  pmr.risk_score,
  pmr.original_title,
  pmr.original_content,
  pmr.created_at
FROM public.prayer_requests pr
LEFT JOIN public.prayer_moderation_reviews pmr
  ON pmr.prayer_request_id = pr.id
WHERE pr.status = 'pending_review'
ORDER BY pr.created_at DESC;


<img width="1888" height="987" alt="image" src="https://github.com/user-attachments/assets/b88d4ee6-74fe-4fef-b799-b22f044ec4ef" />
